### PR TITLE
feat(test): add ci test infrastructure scaffolding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+script: make test-charts

--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,7 @@ dist: build-all
 	$(DIST_DIRS) zip -r helm-{}.zip {} \; && \
 	cd ..
 
+test-charts:
+	@./test/test-charts $(TEST_CHARTS)
 
-.PHONY: build test install clean bootstrap bootstrap-dist build-all dist
+.PHONY: build test install clean bootstrap bootstrap-dist build-all dist test-charts

--- a/test/config.sh
+++ b/test/config.sh
@@ -1,0 +1,13 @@
+TEST_CHARTS="alpine"
+
+# Text color variables
+txtund=$(tput sgr 0 1)          # Underline
+txtbld=$(tput bold)             # Bold
+bldred=${txtbld}$(tput setaf 1) #  red
+bldblu=${txtbld}$(tput setaf 4) #  blue
+bldwht=${txtbld}$(tput setaf 7) #  white
+txtrst=$(tput sgr0)             # Reset
+
+pass="${bldblu}-->${txtrst}"
+warn="${bldred}-->${txtrst}"
+ques="${bldblu}???${txtrst}"

--- a/test/lib.sh
+++ b/test/lib.sh
@@ -1,0 +1,61 @@
+function get-changed-charts {
+  git diff --name-only HEAD origin/HEAD -- charts \
+    | cut -d/ -f 1-2 \
+    | sort \
+    | uniq
+}
+
+function ensure-dirs-exist {
+  local dirs="${@}"
+  local pruned
+
+  # ensure directories exist and just output directory name
+  for dir in ${dirs}; do
+    if [ -d ${dir} ]; then
+      pruned+="$(basename "${dir}")\n"
+    fi
+  done
+
+  echo -e "${pruned}"
+}
+
+function generate-test-plan {
+  ensure-dirs-exist "$(get-changed-charts)"
+}
+
+function run-test-plan {
+  local test_plan
+
+  if is-pull-request; then
+    test_plan="$(generate-test-plan)"
+  else
+    test_plan="${TEST_CHARTS}"
+  fi
+
+  log-lifecycle "Running test plan"
+  log-info "Charts to be tested:"
+  echo "${test_plan}"
+  echo "${test_plan}" | xargs -I {} -P 1 echo \# helm install {} \&\& helm uninstall {}
+}
+
+function is-pull-request {
+  if [ ! -z ${TRAVIS} ] && \
+     [ ${TRAVIS_PULL_REQUEST} != false ]; then
+    log-warn "This is a pull request."
+    return 0
+  else
+    return 1
+  fi
+}
+
+function log-lifecycle {
+  echo "${bldblu}==> ${@}...${txtrst}"
+}
+
+function log-info {
+  echo "${wht}--> ${@}${txtrst}"
+}
+
+function log-warn {
+  echo "${bldred}--> ${@}${txtrst}"
+}

--- a/test/test-charts
+++ b/test/test-charts
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+export THIS_DIR="$(cd "$(dirname $(dirname $0))"; pwd)"
+cd "${THIS_DIR}"
+
+source test/config.sh
+source test/lib.sh
+
+log-lifecycle Building helm
+
+# make helm so we can use it to test changed charts
+# make build test
+
+run-test-plan


### PR DESCRIPTION
Currently the makefile needs some love in other places (why it's commented out inside of the `make test-charts` logic), but this is my idea behind how we test PRs for charts:

If it's a PR, we see what charts have changed and then execute 

```
helm install <chart>
helm test <chart>
helm uninstall <chart>
```

(example: https://travis-ci.org/sgoings/helm/builds/86681185)

If it's master we just run a set of default chart installs (overrideable via TEST_CHARTS env)

Related #4 