### PR TITLE
Update services_and_nameing.md

### DIFF
--- a/docs/services_and_nameing.md
+++ b/docs/services_and_nameing.md
@@ -7,7 +7,7 @@ A may require Package B. This case is accomodated with the
 But a possibly more common scenario would be a service-level dependency:
 Package A requires _a Postgres service_. It doesn't matter to Package A
 whether that's an HA clustered Postgres managed by Governor, or just a
-stand-along Postgres server.
+stand-alone Postgres server.
 
 Kubernetes provides a huge part of the solution: A `service` can be
 declared independent of the actual containers that implement that


### PR DESCRIPTION
docs (change "stand-along" to "stand-alone" line 10): correction of typo

typo

