### PR TITLE
feat(*): add create and edit commands

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,6 +124,8 @@ The command line will support (at least) the following commands:
 - `install CHART`: Fetch the Chart (if necessary) and then install it into Kubernetes, attaching to the k8s server configured for the current user via `kubectl`.
 - `test CHART`: Verifies that the chart can successfully enter the "Running" state (e.g. passes initial health checks)
 - `uninstall CHART`: Uninstall the chart via the k8s server configured for the current user via `kubectl`.
+- `create CHART`: Create a new chart for local editing.
+- `edit CHART`: Edit a local chart with your interactive editor.
 - `info CHART`: Print information about a Chart
 - `update`: Refresh local metadata about available Charts. This will re-pull the repo.
 - `help`: Print help.

--- a/helm/action/create.go
+++ b/helm/action/create.go
@@ -1,0 +1,33 @@
+package action
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+)
+
+import (
+	"github.com/deis/helm/helm/log"
+)
+
+// Create a chart
+//
+// - chartName being created
+// - homeDir is the helm home directory for the user
+func Create(chartName, homeDir string) {
+
+	skeletonDir, _ := filepath.Abs("skel")
+	if fi, err := os.Stat(skeletonDir); err != nil {
+		log.Die("Could not find %s: %s", skeletonDir, err)
+	} else if !fi.IsDir() {
+		log.Die("Malformed skeleton: %s: Must be a directory.", skeletonDir)
+	}
+
+	chartDir := path.Join(homeDir, "workspace", "charts", chartName)
+
+	// copy skeleton to chart directory
+	if err := copyDir(skeletonDir, chartDir); err != nil {
+		log.Die("failed to copy skeleton directory: %v", err)
+	}
+
+}

--- a/helm/action/edit.go
+++ b/helm/action/edit.go
@@ -1,0 +1,164 @@
+package action
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+)
+
+import (
+	"github.com/deis/helm/helm/log"
+)
+
+// delimeterRegexp captures relative path and file content
+var delimeterRegexp = regexp.MustCompile(`--- # (.+)\n([\s\S]*?)--- # end\n`)
+
+// Edit charts using the shell-defined $EDITOR
+//
+// - chartName being edited
+// - homeDir is the helm home directory for the user
+func Edit(chartName, homeDir string) {
+
+	chartDir := path.Join(homeDir, "workspace", "charts", chartName)
+
+	// enumerate chart files
+	files, err := listChart(chartDir)
+	if err != nil {
+		log.Die("could not list chart: %v", err)
+	}
+
+	// join chart with YAML delimeters
+	contents, err := joinChart(chartDir, files)
+	if err != nil {
+		log.Die("could not join chart data: %v", err)
+	}
+
+	// write chart to temporary file
+	f, err := ioutil.TempFile(os.TempDir(), "helm-edit")
+	if err != nil {
+		log.Die("could not open tempfile: %v", err)
+	}
+	defer os.Remove(f.Name())
+	f.Write(contents.Bytes())
+	f.Close()
+
+	openEditor(f.Name())
+	saveChart(chartDir, f.Name())
+
+}
+
+// listChart enumerates all of the relevant files in a chart
+func listChart(chartDir string) ([]string, error) {
+
+	var files []string
+
+	metadataFile := path.Join(chartDir, "Chart.yaml")
+	manifestDir := path.Join(chartDir, "manifests")
+
+	// check for existence of important files and directories
+	for _, path := range []string{chartDir, metadataFile, manifestDir} {
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil, err
+		}
+	}
+
+	// add metadata file to front of list
+	files = append(files, metadataFile)
+
+	// add manifest files
+	walker := func(fname string, fi os.FileInfo, e error) error {
+		if e != nil {
+			log.Warn("Encounter error walking %q: %s", fname, e)
+			return nil
+		}
+
+		if filepath.Ext(fname) == ".yaml" {
+			files = append(files, fname)
+		}
+
+		return nil
+	}
+	filepath.Walk(manifestDir, walker)
+
+	return files, nil
+}
+
+// joinChart reads chart files and joins them with YAML delimiters
+func joinChart(chartDir string, files []string) (bytes.Buffer, error) {
+
+	var output bytes.Buffer
+
+	for _, f := range files {
+		contents, err := ioutil.ReadFile(f)
+		if err != nil {
+			return output, err
+		}
+
+		rf, err := filepath.Rel(chartDir, f)
+		if err != nil {
+			log.Warn("Could not find relative path: %s", err)
+			return output, err
+		}
+
+		delimiter := fmt.Sprintf("--- # %s\n", rf)
+
+		output.WriteString(delimiter)
+		output.Write(contents)
+		output.WriteString("--- # end\n")
+
+	}
+
+	return output, nil
+}
+
+// openEditor opens the given filename in an interactive editor
+func openEditor(filename string) {
+	var cmd *exec.Cmd
+
+	editor := os.ExpandEnv("$EDITOR")
+	if editor == "" {
+		log.Die("must set shell $EDITOR")
+	}
+
+	cmd = exec.Command(editor, filename)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// TODO: figure out why editor always exits non-zero
+	cmd.Run()
+}
+
+// saveChart reads a delimited chart and write out its parts
+// to the workspace directory
+func saveChart(chartDir string, filename string) error {
+
+	// read the serialized chart file
+	contents, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	chartData := make(map[string][]byte)
+
+	// use a regular expression to read file paths and content
+	match := delimeterRegexp.FindAllSubmatch(contents, -1)
+	for _, m := range match {
+		chartData[string(m[1])] = m[2]
+	}
+
+	// save edited chart data to the workdir
+	for k, v := range chartData {
+		fp := path.Join(chartDir, k)
+		if err := ioutil.WriteFile(fp, v, 0644); err != nil {
+			log.Die("could not write chart file", err)
+		}
+	}
+	return nil
+
+}

--- a/helm/action/edit_test.go
+++ b/helm/action/edit_test.go
@@ -1,0 +1,49 @@
+package action
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestListChart(t *testing.T) {
+
+	chartDir, _ := filepath.Abs("../testdata/charts/redis")
+
+	files, err := listChart(chartDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(files) != 2 {
+		t.Fatalf("expected 2, got: %v", len(files))
+	}
+
+}
+
+func TestJoinChart(t *testing.T) {
+
+	chartDir, _ := filepath.Abs("../testdata/charts/redis")
+
+	// prepare files fixture
+	var files []string
+	paths := []string{
+		"../testdata/charts/redis/Chart.yaml",
+		"../testdata/charts/redis/manifests/redis-pod.yaml",
+	}
+	for _, f := range paths {
+		abspath, _ := filepath.Abs(f)
+		files = append(files, abspath)
+	}
+
+	bytes, err := joinChart(chartDir, files)
+	if err != nil {
+		t.Fatalf("failed to join chart: %v", bytes)
+	}
+
+	if bytes.Len() < 1 {
+		t.Fatalf("empty chart after join: %v", bytes)
+	}
+
+}
+
+// TODO: TestSaveChart to test serialization

--- a/helm/helm.go
+++ b/helm/helm.go
@@ -75,6 +75,18 @@ func main() {
 			},
 		},
 		{
+			Name:      "create",
+			Usage:     "Create a chart in the local workspace",
+			ArgsUsage: "[chart-name]",
+			Action:    create,
+		},
+		{
+			Name:      "edit",
+			Usage:     "Edit a named chart in the local workspace",
+			ArgsUsage: "[chart-name]",
+			Action:    edit,
+		},
+		{
 			Name:      "list",
 			Usage:     "List all fetched packages",
 			ArgsUsage: "",
@@ -138,6 +150,14 @@ func install(c *cli.Context) {
 	for _, chart := range c.Args() {
 		action.Install(chart, home(c), c.String("namespace"))
 	}
+}
+
+func create(c *cli.Context) {
+	action.Create(c.Args()[0], home(c))
+}
+
+func edit(c *cli.Context) {
+	action.Edit(c.Args()[0], home(c))
 }
 
 func search(c *cli.Context) {

--- a/helm/testdata/charts/redis/Chart.yaml
+++ b/helm/testdata/charts/redis/Chart.yaml
@@ -1,0 +1,8 @@
+name: redis-standalone
+home: http://github.com/deis/redis
+version: 0.0.1
+description: Simple standalone pod running Redis.
+maintainers:
+  - Gabe Monroy <gabe@deis.com>
+details:
+  This package provides a basic, standalone instance of Redis deployed as a single pod.

--- a/helm/testdata/charts/redis/manifests/redis-pod.yaml
+++ b/helm/testdata/charts/redis/manifests/redis-pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+spec:
+  restartPolicy: Never
+  containers:
+  - name: redis
+  image: redis

--- a/skel/Chart.yaml
+++ b/skel/Chart.yaml
@@ -1,0 +1,10 @@
+name: example-pod
+home: http://github.com/deis/helm
+version: 0.0.1
+description: Example pod running Alpine Linux.
+maintainers:
+  - Gabe Monroy <gabe@deis.com>
+details:
+  This package provides a basic Alpine Linux image that can be used for basic
+  debugging and troubleshooting. By default, it starts up, sleeps for a long
+  time, and then eventually stops.

--- a/skel/README.md
+++ b/skel/README.md
@@ -1,0 +1,3 @@
+# Example Chart
+
+Describe your chart here.

--- a/skel/manifests/example-pod.yaml
+++ b/skel/manifests/example-pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: alpine
+spec:
+  restartPolicy: Never
+  containers:
+  - name: alpine
+  image: "alpine:3.2"
+    command: ["/bin/sleep","9000"]


### PR DESCRIPTION
This PR adds `helm create` and `helm edit` commands which make for a nice contributor workflow.

Note a lot of this code will have to be refactored once we move chart serialization/deserialization into the `model` package.

Example of `helm create`:

```console
$ helm create mychart
Copying /Users/gabriel/workspace/src/github.com/deis/helm/skel
Copying /Users/gabriel/workspace/src/github.com/deis/helm/skel/Chart.yaml
Copying /Users/gabriel/workspace/src/github.com/deis/helm/skel/README.md
Copying /Users/gabriel/workspace/src/github.com/deis/helm/skel/manifests
Copying /Users/gabriel/workspace/src/github.com/deis/helm/skel/manifests/example-pod.yaml
```

Example of `helm edit` which opens in `$EDITOR` and saves the results:

```console
$ helm edit mychart
--- # Chart.yaml
name: example-pod-2
home: http://github.com/deis/helm
version: 0.0.1
description: Example pod running Alpine Linux.
maintainers:
  - Gabe Monroy <gabe@deis.com>
details:
  This package provides a basic Alpine Linux image that can be used for basic
  debugging and troubleshooting. By default, it starts up, sleeps for a long
  time, and then eventually stops.
--- # end
--- # manifests/example-pod.yaml
apiVersion: v1
kind: Pod
metadata:
  name: alpine
spec:
  restartPolicy: Never
  containers:
  - name: alpine
  image: "alpine:3.2"
    command: ["/bin/sleep","9000"]
--- # end
```

Closes #8.