### PR TITLE
ref(action): s/WorkDirChartPath/WorkspaceChartPath/

### DIFF
--- a/helm/action/action.go
+++ b/helm/action/action.go
@@ -1,0 +1,12 @@
+package action
+
+// CachePath is the suffix for the cache.
+const CachePath = "cache"
+const CacheChartPath = "cache/charts"
+
+const WorkspacePath = "workspace"
+const WorkspaceChartPath = "workspace/charts"
+
+const DefaultNS = "default"
+
+var helmpaths = []string{CachePath, WorkspacePath}

--- a/helm/action/create.go
+++ b/helm/action/create.go
@@ -23,7 +23,7 @@ func Create(chartName, homeDir string) {
 		log.Die("Malformed skeleton: %s: Must be a directory.", skeletonDir)
 	}
 
-	chartDir := path.Join(homeDir, "workspace", "charts", chartName)
+	chartDir := path.Join(homeDir, WorkspaceChartPath, chartName)
 
 	// copy skeleton to chart directory
 	if err := copyDir(skeletonDir, chartDir); err != nil {

--- a/helm/action/edit.go
+++ b/helm/action/edit.go
@@ -152,7 +152,7 @@ func saveChart(chartDir string, filename string) error {
 		chartData[string(m[1])] = m[2]
 	}
 
-	// save edited chart data to the workdir
+	// save edited chart data to the workspace
 	for k, v := range chartData {
 		fp := path.Join(chartDir, k)
 		if err := ioutil.WriteFile(fp, v, 0644); err != nil {

--- a/helm/action/fetch.go
+++ b/helm/action/fetch.go
@@ -20,7 +20,7 @@ func Fetch(chart, lname, homedir string) {
 		lname = chart
 	}
 	src := filepath.Join(homedir, CacheChartPath, chart)
-	dest := filepath.Join(homedir, WorkdirChartPath, lname)
+	dest := filepath.Join(homedir, WorkspaceChartPath, lname)
 
 	if fi, err := os.Stat(src); err != nil {
 	} else if !fi.IsDir() {

--- a/helm/action/info.go
+++ b/helm/action/info.go
@@ -1,0 +1,27 @@
+package action
+
+import (
+	"path/filepath"
+
+	"github.com/deis/helm/helm/log"
+	"github.com/deis/helm/helm/model"
+)
+
+func Info(chart, homedir string) {
+	chartPath := filepath.Join(homedir, CacheChartPath, chart, "Chart.yaml")
+
+	log.Info("%s", chartPath)
+
+	chartModel, err := model.Load(chartPath)
+	if err != nil {
+		log.Die("%s - UNKNOWN", chart)
+	}
+
+	log.Info("Chart: %s", chartModel.Name)
+	log.Info("Description: %s", chartModel.Description)
+	log.Info("Details: %s", chartModel.Details)
+	log.Info("Version: %s", chartModel.Version)
+	log.Info("Website: %s", chartModel.Home)
+	log.Info("From: %s", chartPath)
+	log.Info("Dependencies: %s", chartModel.Dependencies)
+}

--- a/helm/action/install.go
+++ b/helm/action/install.go
@@ -19,7 +19,7 @@ func Install(chart, home, namespace string) {
 		Fetch(chart, chart, home)
 	}
 
-	d := filepath.Join(home, WorkdirChartPath, chart, "manifests")
+	d := filepath.Join(home, WorkspaceChartPath, chart, "manifests")
 	log.Debug("Looking for manifests in %q", d)
 	files, err := manifestFiles(d)
 	if err != nil {
@@ -37,7 +37,7 @@ func Install(chart, home, namespace string) {
 //
 // This does NOT check the Chart.yaml file.
 func chartInstalled(chart, home string) bool {
-	p := filepath.Join(home, WorkdirChartPath, chart, "Chart.yaml")
+	p := filepath.Join(home, WorkspaceChartPath, chart, "Chart.yaml")
 	log.Debug("Looking for %q", p)
 	if fi, err := os.Stat(p); err != nil || fi.IsDir() {
 		log.Debug("No chart: %s", err)

--- a/helm/action/list.go
+++ b/helm/action/list.go
@@ -9,7 +9,7 @@ import (
 
 // List lists all of the local charts.
 func List(homedir string) {
-	md := filepath.Join(homedir, WorkdirChartPath, "*")
+	md := filepath.Join(homedir, WorkspaceChartPath, "*")
 	charts, err := filepath.Glob(md)
 	if err != nil {
 		log.Warn("Could not find any charts in %q: %s", md, err)

--- a/helm/action/update.go
+++ b/helm/action/update.go
@@ -10,17 +10,6 @@ import (
 	"github.com/deis/helm/helm/log"
 )
 
-// CachePath is the suffix for the cache.
-const CachePath = "cache"
-const CacheChartPath = "cache/charts"
-
-const WorkdirPath = "workspace"
-const WorkdirChartPath = "workspace/charts"
-
-const DefaultNS = "default"
-
-var helmpaths = []string{CachePath, WorkdirPath}
-
 // Update fetches the remote repo into the home directory.
 func Update(repo, home string) {
 	home, err := filepath.Abs(home)


### PR DESCRIPTION
* `WorkDirChartPath` is redundant
* refactor globals to `action.go`