### PR TITLE
Charts for Standalone Redis and Example Todo App

### DIFF
--- a/charts/example-todo/Chart.yaml
+++ b/charts/example-todo/Chart.yaml
@@ -1,0 +1,8 @@
+name: example-todo
+home: http://github.com/gabrtv/example-todo
+version: 0.0.1
+description: This is an example todo app backed by Redis.
+maintainers:
+  - Gabe Monroy <gabe@deis.com>
+details:
+  This package provides an example todo web service backed by Redis.

--- a/charts/example-todo/manifests/example-todo-rc.yaml
+++ b/charts/example-todo/manifests/example-todo-rc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: example-todo
+spec:
+  replicas: 1
+  selector:
+    name: example-todo
+  template:
+    metadata:
+      labels:
+        name: example-todo
+    spec:
+      containers:
+      - name: example-todo
+        image: "deis/example-todo:v0.0.1"
+        ports:
+        - containerPort: 3000

--- a/charts/example-todo/manifests/example-todo-redis-service.yaml
+++ b/charts/example-todo/manifests/example-todo-redis-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-todo-redis
+  labels:
+    heritage: deis
+spec:
+  ports:
+    - port: 6379
+      name: redis
+      protocol: TCP
+  selector:
+    provider: redis

--- a/charts/example-todo/manifests/example-todo-service.yaml
+++ b/charts/example-todo/manifests/example-todo-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-todo
+  labels:
+    heritage: deis
+spec:
+  type: NodePort
+  ports:
+    - port: 3000
+      nodePort: 30000
+      name: http
+      protocol: TCP
+  selector:
+    name: example-todo

--- a/charts/redis-standalone/Chart.yaml
+++ b/charts/redis-standalone/Chart.yaml
@@ -1,0 +1,9 @@
+name: redis-standalone
+home: http://github.com/deis/helm
+version: 0.0.1
+description: Standalone Redis Master
+maintainers:
+  - Gabe Monroy <gabe@deis.com>
+details:
+  This package provides a standalone Redis master useful for prototyping.
+  Note this does not include any high availability.

--- a/charts/redis-standalone/README.md
+++ b/charts/redis-standalone/README.md
@@ -1,0 +1,3 @@
+# Redis Standalone
+
+This is a standalone Redis master with no high-availability, useful for rapid prototyping.

--- a/charts/redis-standalone/manifests/redis-rc.yaml
+++ b/charts/redis-standalone/manifests/redis-rc.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: redis-standalone
+spec:
+  replicas: 1
+  selector:
+    name: redis-standalone
+    mode: standalone
+    provider: redis
+  template:
+    metadata:
+      labels:
+        name: redis-standalone
+        mode: standalone
+        provider: redis
+    spec:
+      containers:
+      - name: redis-standalone
+        image: kubernetes/redis:v1
+        env:
+        - name: MASTER
+          value: "true"
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - mountPath: /redis-master-data
+          name: data
+      volumes:
+        - name: data
+          emptyDir: {}


### PR DESCRIPTION
These charts work together to provide a working Todo App that uses Helm-conventions to facilitate Kubernetes-native service discovery via environment variables.  Note the example app is currently bound to the cluster `NodePort` of `30000`.