### PR TITLE
bug(deps) speter.net/go/exp/math/dec/inf

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,13 @@
 package: github.com/deis/helm
 import:
+  - package: k8s.io/kubernetes
+    ref:     2e5a3cfbc62e4a63423f43f2e6d5723806569b17
+    subpackages:
+      - /pkg
   - package: github.com/Masterminds/vcs
   - package: github.com/Masterminds/semver
   - package: gopkg.in/yaml.v2
   - package: golang.org/x/crypto
   - package: github.com/codegangsta/cli
-    ref: f445c894402839580d30de47551cedc152dad814
-  - package: k8s.io/kubernetes
-    ref: 2e5a3cfbc62e4a63423f43f2e6d5723806569b17
-    subpackages:
-      - /pkg
+    ref:     f445c894402839580d30de47551cedc152dad814
+  - package: speter.net/go/exp/math/dec/inf


### PR DESCRIPTION
Needed to manuall `glide get` this dependency with a clean `$GOPATH` and a `glide up`.

Fixes:
```
helm [master]$ make build
go build -o helm.bin -ldflags "-X main.version=" helm/helm.go
vendor/k8s.io/kubernetes/pkg/api/resource/quantity.go:27:2: cannot find package "speter.net/go/exp/math/dec/inf" in any of:
	/Users/jhansen/p/go/src/github.com/deis/helm/vendor/speter.net/go/exp/math/dec/inf (vendor tree)
	/usr/local/Cellar/go/1.5.1/libexec/src/speter.net/go/exp/math/dec/inf (from $GOROOT)
	/Users/jhansen/p/go/src/speter.net/go/exp/math/dec/inf (from $GOPATH)
make: *** [build] Error 1
```