### PR TITLE
doc(skel) make the skeleton Chart generic

### DIFF
--- a/skel/Chart.yaml
+++ b/skel/Chart.yaml
@@ -1,10 +1,9 @@
 name: example-pod
-home: http://github.com/deis/helm
+home: http://example.com/your/project/home
 version: 0.0.1
-description: Example pod running Alpine Linux.
+description: Provide a brief description of your application here.
 maintainers:
-  - Gabe Monroy <gabe@deis.com>
+  - Your Name <email@address>
 details:
-  This package provides a basic Alpine Linux image that can be used for basic
-  debugging and troubleshooting. By default, it starts up, sleeps for a long
-  time, and then eventually stops.
+  This section allows you to provide additional details about your application.
+  Provide any information that would be useful to users at a glance.

--- a/skel/README.md
+++ b/skel/README.md
@@ -1,3 +1,13 @@
 # Example Chart
 
-Describe your chart here.
+Describe your chart here. Link to upstream repositories, Docker images or any
+external documentation.
+
+If your application requires any specific configuration like Secrets, you may
+include that information here.
+
+# Changelog
+
+## [0.0.1] - 2015-10-26
+
+- Initial release.

--- a/skel/manifests/example-pod.yaml
+++ b/skel/manifests/example-pod.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: alpine
+  name: example-pod
 spec:
   restartPolicy: Never
   containers:
-  - name: alpine
+  - name: example
   image: "alpine:3.2"
     command: ["/bin/sleep","9000"]


### PR DESCRIPTION
Make the skeleton more generic. Prompt for the things we would like to see.

Might also be a good opportunity to expand the skeleton to include a Service definition, so we can explain our approach to labels in situ.