### PR TITLE
chore(*): clean up the helm.go file

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -13,8 +13,30 @@ const version = "0.0.1"
 func main() {
 	app := cli.NewApp()
 	app.Name = "helm"
-	app.Usage = "The Kubernetes package manager"
+	app.Usage = `The Kubernetes package manager
+
+To begin working with Helm, run the 'helm update' command:
+
+	$ helm update
+
+This will download all of the necessary data. Common actions from this point
+include:
+
+	- helm help COMMAND: see help for a specific command
+	- helm search: search for charts
+	- helm fetch: make a local working copy of a chart
+	- helm install: upload the chart to Kubernetes
+
+For more information on Helm, go to http://helm.sh.
+
+ENVIRONMENT:
+   $HELM_HOME:     Set an alternative location for Helm files. By default, these
+                   are stored in ~/.helm
+   $HELM_REPO_URL: Set an alternative upstream chart repository.
+
+`
 	app.Version = version
+	app.EnableBashCompletion = true
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
@@ -37,14 +59,32 @@ func main() {
 
 	app.Commands = []cli.Command{
 		{
-			Name:      "update",
-			Usage:     "Get the latest version of all Charts from GitHub.",
+			Name:  "update",
+			Usage: "Get the latest version of all Charts from GitHub.",
+			Description: `This will synchronize the local repository with the upstream GitHub project.
+The local cached copy is stored in '~/.helm/cache' or (if specified)
+'$HELM_HOME/cache'.
+
+The first time 'helm update' is run, the necessary directory structures are
+created and then the Git repository is pulled in full.
+
+Subsequent calls to 'helm update' will simply synchronize the local cache
+with the remote.`,
 			ArgsUsage: "",
-			Action:    update,
+			Action: func(c *cli.Context) {
+				action.Update(repo(c), home(c))
+			},
 		},
 		{
-			Name:      "fetch",
-			Usage:     "Fetch a Chart to your working directory.",
+			Name:  "fetch",
+			Usage: "Fetch a Chart to your working directory.",
+			Description: `Copy a chart from the Chart repository to a local workspace.
+From this point, the copied chart may be safely modified to your needs.
+
+If an optional 'chart-name' is specified, the chart will be copied to a directory
+of that name. For example, 'helm fetch nginx www' will copy the the contents of
+the 'nginx' chart into a directory named 'www' in your workspace.
+`,
 			ArgsUsage: "[chart] [chart-name]",
 			Action:    fetch,
 			Flags: []cli.Flag{
@@ -56,14 +96,20 @@ func main() {
 			},
 		},
 		{
-			Name:      "build",
-			Usage:     "(Re-)build a manifest from templates.",
-			ArgsUsage: "[chart-name...]",
-			Action:    build,
-		},
-		{
-			Name:      "install",
-			Usage:     "Install a named package into Kubernetes.",
+			Name:  "install",
+			Usage: "Install a named package into Kubernetes.",
+			Description: `If the given 'chart-name' is present in your workspace, it
+will be uploaded into Kubernetes. If no chart named 'chart-name' is found in
+your workspace, Helm will look for a chart with that name, install it into the
+workspace, and then immediately upload it to Kubernetes.
+
+When multiple charts are specified, Helm will attempt to install all of them,
+following the resolution process described above.
+
+As a special case, if the flag --chart-path is specified, Helm will look for a
+Chart.yaml file and manifests/ directory at that path, and will install that
+chart if found. In this case, you may not specify multiple charts at once.
+`,
 			ArgsUsage: "[chart-name...]",
 			Action:    install,
 			Flags: []cli.Flag{
@@ -75,10 +121,20 @@ func main() {
 			},
 		},
 		{
-			Name:      "uninstall",
-			Usage:     "Uninstall a named package from Kubernetes.",
+			Name:  "uninstall",
+			Usage: "Uninstall a named package from Kubernetes.",
+			Description: `For each supplied 'chart-name', this will connect to Kubernetes
+and remove all of the manifests specified.
+
+This will not alter the charts in your workspace.
+`,
 			ArgsUsage: "[chart-name...]",
-			Action:    uninstall,
+			Action: func(c *cli.Context) {
+				minArgs(c, 1, "uninstall")
+				for _, chart := range c.Args() {
+					action.Uninstall(chart, home(c), c.String("namespace"))
+				}
+			},
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  "namespace, n",
@@ -88,52 +144,87 @@ func main() {
 			},
 		},
 		{
-			Name:      "create",
-			Usage:     "Create a chart in the local workspace",
+			Name:  "create",
+			Usage: "Create a chart in the local workspace.",
+			Description: `This will scaffold a new chart named 'chart-name' in your
+local workdir. To edit the resulting chart, you may edit the files directly or
+use the 'helm edit' command.
+`,
 			ArgsUsage: "[chart-name]",
-			Action:    create,
+			Action: func(c *cli.Context) {
+				minArgs(c, 1, "create")
+				action.Create(c.Args()[0], home(c))
+			},
 		},
 		{
-			Name:      "edit",
-			Usage:     "Edit a named chart in the local workspace",
+			Name:  "edit",
+			Usage: "Edit a named chart in the local workspace.",
+			Description: `Existing charts in the workspace can be edited using this command.
+'helm edit' will open all of the chart files in a single editor (as specified
+by the $EDITOR environment variable).
+`,
 			ArgsUsage: "[chart-name]",
-			Action:    edit,
+			Action: func(c *cli.Context) {
+				minArgs(c, 1, "edit")
+				action.Edit(c.Args()[0], home(c))
+			},
 		},
 		{
-			Name:      "publish",
-			Usage:     "Publish a named chart to the git checkout",
+			Name:  "publish",
+			Usage: "Publish a named chart to the git checkout.",
+			Description: `This copies a chart from the workdir into the cache. Doing so
+is the first stage of contributing a chart upstream.
+`,
 			ArgsUsage: "[chart-name]",
-			Action:    publish,
+			Action: func(c *cli.Context) {
+				action.Publish(c.Args()[0], home(c), c.Bool("force"))
+			},
 			Flags: []cli.Flag{
 				cli.BoolFlag{
 					Name:  "force, f",
-					Usage: "Force publish over an existing chart",
+					Usage: "Force publish over an existing chart.",
 				},
 			},
 		},
 		{
-			Name:      "list",
-			Usage:     "List all fetched packages",
+			Name:  "list",
+			Usage: "List all fetched packages.",
+			Description: `This prints all of the packages that are currently installed in
+the workspace. Packages are printed by the local name.
+`,
 			ArgsUsage: "",
-			Action:    list,
+			Action: func(c *cli.Context) {
+				action.List(home(c))
+			},
 		},
 		{
-			Name:      "search",
-			Usage:     "Search for a package",
+			Name:  "search",
+			Usage: "Search for a package.",
+			Description: `This provides a simple interface for searching the chart cache
+for charts matching a given pattern.
+
+If no string is provided, or if the special string '*' is provided, this will
+list all available charts.
+`,
 			ArgsUsage: "[string]",
 			Action:    search,
 		},
 		{
 			Name:      "info",
-			Usage:     "Print information about a Chart",
+			Usage:     "Print information about a Chart.",
 			ArgsUsage: "[string]",
-			Action:    info,
+			Action: func(c *cli.Context) {
+				minArgs(c, 1, "info")
+				action.Info(c.Args()[0], home(c))
+			},
 		},
 		{
 			Name:      "target",
-			Usage:     "Displays information about cluster",
+			Usage:     "Displays information about cluster.",
 			ArgsUsage: "",
-			Action:    target,
+			Action: func(c *cli.Context) {
+				action.Target()
+			},
 		},
 	}
 
@@ -153,14 +244,6 @@ func repo(c *cli.Context) string {
 	return os.ExpandEnv(c.GlobalString("repo"))
 }
 
-func update(c *cli.Context) {
-	action.Update(repo(c), home(c))
-}
-
-func list(c *cli.Context) {
-	action.List(home(c))
-}
-
 func fetch(c *cli.Context) {
 	home := home(c)
 	minArgs(c, 1, "fetch")
@@ -176,14 +259,6 @@ func fetch(c *cli.Context) {
 	action.Fetch(chart, lname, home)
 }
 
-func build(c *cli.Context) {
-	home := home(c)
-
-	for _, chart := range c.Args() {
-		action.Build(chart, home)
-	}
-}
-
 func install(c *cli.Context) {
 	minArgs(c, 1, "install")
 	for _, chart := range c.Args() {
@@ -191,40 +266,9 @@ func install(c *cli.Context) {
 	}
 }
 
-func uninstall(c *cli.Context) {
-	minArgs(c, 1, "uninstall")
-	for _, chart := range c.Args() {
-		action.Uninstall(chart, home(c), c.String("namespace"))
-	}
-}
-
-func create(c *cli.Context) {
-	minArgs(c, 1, "create")
-	action.Create(c.Args()[0], home(c))
-}
-
-func edit(c *cli.Context) {
-	minArgs(c, 1, "edit")
-	action.Edit(c.Args()[0], home(c))
-}
-
-func publish(c *cli.Context) {
-	action.Publish(c.Args()[0], home(c), c.Bool("force"))
-}
-
 func search(c *cli.Context) {
 	minArgs(c, 1, "search")
 	action.Search(c.Args()[0], home(c))
-}
-
-func info(c *cli.Context) {
-	minArgs(c, 1, "info")
-
-	action.Info(c.Args()[0], home(c))
-}
-
-func target(c *cli.Context) {
-	action.Target()
 }
 
 // minArgs checks to see if the right number of args are passed.


### PR DESCRIPTION
The following changes were made to helm.go:

- All small command functions were collapsed back into the app
  command objects. This seems to be much easier to work with.
- Descriptions were added to all commands that required more help
  text.
- Bash/Zsh autocompletion was enabled. Users still need to source
  the requisite files into their shell, though.