### PR TITLE
chore(*): filename mismatch in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,6 @@ site_name: Helm Documentation
 pages:
  - Home: index.md
  - Architecture: architecture.md
- - Services and Naming: services_and_nameing.md
+ - Services and Naming: services_and_naming.md
  - UI Design: ui_design.md
 theme: readthedocs


### PR DESCRIPTION
According to the OED, 'nameing' is an authoritatively quoted spelling from 1566:

*J. Knox Hist. Reformation in Wks. (1846) I. 431*
> "To command free Browchis to cheise Provestis and officiaris of our nameing."

and as recently as 1678:

*Grant Coal Shillings to Duke of Richmond 18 Dec. in J. Brand Hist. & Antiq. Newcastle (1789) II. 671*
> "The..misnameing or not nameing of any demise or grant."

**and** by no less an authority than Milton! in 1670:

*Milton Hist. Brit. iv. 182*
> "So different they often are one from another, both in timeing and in nameing."

It would thus be rash to call "nameing" a typo; but it's probably best to reconcile the reference in mkdocs.yml with the actual filename by adopting the contemporary orthographic idiom.