### PR TITLE
feat(ci): publish binaries to Bintray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 vendor/
-helm.bin
+bin/
+dist/
+ci/bintray-ci.json
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,15 @@ install:
   - export PATH="$PATH:$GLIDE_DIR"
 
 script: make bootstrap build test test-charts
+
+before_deploy: make bootstrap-dist dist prep-bintray-json
+
+deploy:
+- provider: bintray
+  file: ci/bintray-ci.json
+  user: deis-admin
+  key:
+    secure: "c7bWThGpO9vE/A1ePSW/kyhJPOVl6COsWK+199PVuQz1G3mB5xL0FUA21qGp25RAGyJW/iBBp6CQRCKXksnlicwgVk8cOyiYhy1tsxo06c6aAtuf8FBP+EIXtvqlH5QTskvkQzKfhUsYFVoXVr0VRIFcNYejBl/npWdvLy+sz90a8L3JuZ/RbMEYXgQ85SqLUR5OvEKI1C078i10RGcnQNcxOrcl71sB+1nDux3h0wXEzOKkHsmFd7CBNvgNnGx6ugV+YFj6TwfezE2LiWtGugbto1TY9PEGZsEg6I0eKvqXmoWTghd92QF22EEc81C8WJH56Ew/3vMnQlGGgUzhpy982gFSSLo73zb/6HwSC6LdBa6Jjg5L6xWiRteyX6dYFobGRrHytX6q6Q7lrM43Q9FwdIxlqKSyr7wZIOFg+uG3B/W/8Q6EXx7vnSJsUuO5P9QDpTQqAQakJ4gyq68WsPx0E3trLA3326Fum/GfnawiXJmtTHhdTvY3RGS0Pt6FWBBoaN2oHObaciMd77jq6auDCzO4wgx+LoBcekM3QOoEAVx/ASXfzxgZAvur7RK+opzPzHCR3sWpFloasNeSMXq2fJLhWo/DQWNxWisDmZ6JVgf9S15N5S896lpiND1JqgQDNJcbad5dpEhfthJzKDPneXOuqEna+fpfCZ/OPS0="
+  on:
+    branch: master
+    tags: true

--- a/Makefile
+++ b/Makefile
@@ -2,22 +2,9 @@ VERSION := $(shell git describe --tags 2>/dev/null)
 DIST_DIRS := find * -type d -exec
 export GO15VENDOREXPERIMENT=1
 
-build:
-	go build -o helm.bin -ldflags "-X main.version=${VERSION}" helm/helm.go
-
-install: build
-	install -d ${DESTDIR}/usr/local/bin/
-	install -m 755 ./helm.bin ${DESTDIR}/usr/local/bin/helm
-
-test:
-	go test -v ./helm/. ./helm/manifest ./helm/action ./helm/log ./helm/model ./helm/dependency
-
-quicktest:
-	go test ./helm/. ./helm/manifest ./helm/action ./helm/log ./helm/model ./helm/dependency
-
-clean:
-	rm -f ./helm/helm.test
-	rm -f ./helm.bin
+ifndef VERSION
+  VERSION := git-$(shell git rev-parse --short HEAD)
+endif
 
 bootstrap:
 	glide -y glide-full.yaml up
@@ -25,21 +12,57 @@ bootstrap:
 bootstrap-dist:
 	go get -u github.com/mitchellh/gox
 
+build:
+	go build -o bin/helm -ldflags "-X main.version=${VERSION}" helm/helm.go
+
 build-all:
+	@cd helm && \
 	gox -verbose \
 	-ldflags "-X main.version=${VERSION}" \
-	-os="linux darwin windows " \
+	-os="linux darwin " \
 	-arch="amd64 386" \
-	-output="dist/{{.OS}}-{{.Arch}}/{{.Dir}}" .
+	-output="../dist/{{.OS}}-{{.Arch}}/{{.Dir}}" . && \
+	cd ..
+
+clean:
+	rm -f ./helm/helm.test
+	rm -f ./helm.bin
 
 dist: build-all
-	cd dist && \
-	$(DIST_DIRS) cp ../LICENSE.txt {} \; && \
-	$(DIST_DIRS) cp ../README.md {} \; && \
-	$(DIST_DIRS) zip -r helm-{}.zip {} \; && \
-	cd ..
+	@cd dist && \
+  $(DIST_DIRS) zip -jr helm-$(VERSION)-{}.zip {} \; && \
+  cd ..
+
+install: build
+	install -d ${DESTDIR}/usr/local/bin/
+	install -m 755 bin/helm ${DESTDIR}/usr/local/bin/helm
+
+prep-bintray-json:
+# TRAVIS_TAG is set to the tag name if the build is a tag
+ifdef TRAVIS_TAG
+	@jq '.version.name |= "$(VERSION)"' ci/bintray-template.json | \
+		jq '.package.repo |= "helm"' > ci/bintray-ci.json
+else
+	@jq '.version.name |= "$(VERSION)"' ci/bintray-template.json \
+		> ci/bintray-ci.json
+endif
+
+quicktest:
+	go test ./helm/. ./helm/manifest ./helm/action ./helm/log ./helm/model ./helm/dependency
+
+test:
+	go test -v ./helm/. ./helm/manifest ./helm/action ./helm/log ./helm/model ./helm/dependency
 
 test-charts:
 	@./test/test-charts $(TEST_CHARTS)
 
-.PHONY: build test install clean bootstrap bootstrap-dist build-all dist test-charts
+.PHONY: bootstrap \
+				bootstrap-dist \
+				build \
+				build-all \
+				clean \
+				dist \
+				install \
+				prep-bintray-json \
+				test \
+				test-charts

--- a/ci/bintray-template.json
+++ b/ci/bintray-template.json
@@ -1,0 +1,17 @@
+{
+  "package": {
+    "name": "helm",
+    "repo": "helm-ci",
+    "subject": "deis"
+  },
+  "version": {
+    "name": "0.0.0"
+  },
+  "files": [
+    {
+      "includePattern": "dist/(.*)",
+      "uploadPattern": "$1"
+    }
+  ],
+  "publish": true
+}


### PR DESCRIPTION
If the master branch is changed, published binaries end up in the helm-ci repository: https://bintray.com/deis/helm-ci/helm/

If it's a release (has a tag), the binaries will be pushed to https://bintray.com/deis/helm/helm/ with the version being the tag name.

No binaries are published on pull requests.

Fixes #93 