### PR TITLE
feat(*): add log.Logger and set Git to write to it

### DIFF
--- a/helm/log/log.go
+++ b/helm/log/log.go
@@ -16,7 +16,7 @@ var IsDebugging = false
 
 // New creates a *log.Logger that writes to this source.
 func New() *log.Logger {
-	ll := log.New(Stdout, pretty.Colorize("{{.Yellow}}---->{{.Default}}"), 0)
+	ll := log.New(Stdout, pretty.Colorize("{{.Yellow}}--->{{.Default}} "), 0)
 	return ll
 }
 


### PR DESCRIPTION
This gives better output from the Git commands, including catching full Git errors when they happen.