### PR TITLE
test(travis): speed up glide pkg handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ branches:
   only:
     - master
 
+cache:
+  directories:
+    - $GOPATH/src/github.com/deis/helm/vendor
+
 go:
   - 1.5.1
 


### PR DESCRIPTION
Leverage the travis cache system to speed up dependency handling.

The first time through the `vendor/` directory will be populated and the slower speed. After the first pass it will be cached and only updates to the packages will be pulled down. This should provide a dramatic speedup. In my own testing of helm I saw it take ~20s to handle dependencies in `vendor/` with a warm cache.