### PR TITLE
feat(helm): show help text for invalid commands

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -57,6 +57,12 @@ ENVIRONMENT:
 		},
 	}
 
+	app.CommandNotFound = func(c *cli.Context, command string) {
+		log.Err("No matching command '%s'", command)
+		cli.ShowAppHelp(c)
+		log.Die("")
+	}
+
 	app.Commands = []cli.Command{
 		{
 			Name:  "update",


### PR DESCRIPTION
Previously, users would see a confusing "No help topic for 'command'"
when trying to run an invalid command. Now, they see an appropriate
message and the usage text.

fixes #128