### PR TITLE
Cleanup Helm CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,10 @@ To quickly install a standalone etcd instance:
 
 ```
 $ helm update
----> Fetching updates...
+---> Cloning into '$HOME/.helm/cache/charts'...
+---> Updating cache from https://github.com/deis/charts
 ---> Done
 $ helm search redis
----> =================
----> Available Charts
----> =================
---->
 ---> 	redis-cluster (redis-cluster 0.0.5) - Highly available Redis cluster with multiple sentinels and standbys.
 ---> 	redis-standalone (redis-standalone 0.0.1) - Standalone Redis Master
 $ helm info redis-cluster
@@ -49,26 +46,35 @@ Version: 0.0.5
 Description: Highly available Redis cluster with multiple sentinels and standbys.
 Details: This package provides a highly available Redis cluster with multiple sentinels and standbys. Note the `redis-master` pod is used for bootstrapping only and can be deleted once the cluster is up and running.
 $ helm install redis-cluster
----> Downloading etcd-standalone-2.2.0-beta3
----> Cached files into $HELM_WORKDIR/charts/etcd-standalone/
----> Running kubectl create -f ...
+---> No chart named "redis-cluster" in your workspace. Fetching now.
+---> Fetched chart into workspace /Users/gabriel/.helm/workspace/charts/redis-cluster
+---> Running `kubectl create -f` ...
+services/redis-sentinel
+pods/redis-master
+replicationcontrollers/redis
+replicationcontrollers/redis-sentinel
 ---> Done
 ```
 
-To fetch, customize and install the same chart:
+To fetch, modify and install a chart out of your local workspace:
 
 ```
 $ helm update
----> Fetching updates...
+---> Updating cache from https://github.com/deis/charts
 ---> Done
-$ helm fetch etcd-standalone etcd
----> Downloading etcd-standalone-2.2.0-beta3
----> Cached files into $HELM_WORKDIR/charts/etcd/
+$ helm fetch redis-standalone redis
+---> Fetched chart into workspace /Users/gabriel/.helm/workspace/charts/redis
 ---> Done
-$ helm edit etcd
-$ helm install etcd
----> Found etcd in $HELM_WORKDIR/charts/etcd/ ...
----> Running kubectl create -f ...
+$ helm edit redis
+$ helm install redis
+---> Running `kubectl create -f` ...
+replicationcontrollers/redis-standalone
+---> Done
+========================================
+# Redis Standalone
+
+This is a standalone Redis master with no high-availability, useful for rapid prototyping.
+========================================
 ```
 
 ## Contributing to the Helm CLI

--- a/action/fetch.go
+++ b/action/fetch.go
@@ -42,7 +42,8 @@ func Fetch(chartName, lname, homedir string) {
 		}
 	}
 
-	PrintREADME(lname, homedir)
+	log.Info("Fetched chart into workspace %s", filepath.Join(homedir, WorkspaceChartPath, lname))
+	log.Info("Done")
 }
 
 func fetch(chartName, lname, homedir string) {
@@ -58,7 +59,7 @@ func fetch(chartName, lname, homedir string) {
 		log.Die("Could not create %q: %s", dest, err)
 	}
 
-	log.Info("Fetching %s to %s", src, dest)
+	log.Debug("Fetching %s to %s", src, dest)
 	if err := copyDir(src, dest); err != nil {
 		log.Die("Failed copying %s to %s", src, dest)
 	}
@@ -76,7 +77,7 @@ func copyDir(src, dst string) error {
 			return nil
 		}
 
-		log.Info("Copying %s", fname)
+		log.Debug("Copying %s", fname)
 		rf, err := filepath.Rel(src, fname)
 		if err != nil {
 			log.Warn("Could not find relative path: %s", err)

--- a/action/install.go
+++ b/action/install.go
@@ -27,8 +27,8 @@ import (
 // 	- Pods
 // 	- ReplicationControllers
 func Install(chartName, home, namespace string, force bool) {
-	if !chartInstalled(chartName, home) {
-		log.Info("No installed chart named %q. Installing now.", chartName)
+	if !chartFetched(chartName, home) {
+		log.Info("No chart named %q in your workspace. Fetching now.", chartName)
 		fetch(chartName, chartName, home)
 	}
 
@@ -55,9 +55,12 @@ func Install(chartName, home, namespace string, force bool) {
 		}
 	}
 
+	log.Info("Running `kubectl create -f` ...")
 	if err := uploadManifests(c, namespace); err != nil {
 		log.Die("Failed to upload manifests: %s", err)
 	}
+	log.Info("Done")
+
 	PrintREADME(chartName, home)
 }
 
@@ -170,10 +173,10 @@ func uploadManifests(c *chart.Chart, namespace string) error {
 	return nil
 }
 
-// Check by chart directory name whether a chart is installed.
+// Check by chart directory name whether a chart is fetched into the workspace.
 //
 // This does NOT check the Chart.yaml file.
-func chartInstalled(chartName, home string) bool {
+func chartFetched(chartName, home string) bool {
 	p := filepath.Join(home, WorkspaceChartPath, chartName, "Chart.yaml")
 	log.Debug("Looking for %q", p)
 	if fi, err := os.Stat(p); err != nil || fi.IsDir() {
@@ -204,7 +207,7 @@ func kubectlCreate(data []byte, ns string) error {
 		return err
 	}
 
-	log.Info("File: %s", string(data))
+	log.Debug("File: %s", string(data))
 	in.Write(data)
 	in.Close()
 

--- a/action/search.go
+++ b/action/search.go
@@ -18,12 +18,6 @@ func Search(term, homedir string) {
 		log.Die(err.Error())
 	}
 
-	log.Info("=================")
-	log.Info("Available Charts")
-	log.Info("=================")
-
-	log.Info("")
-
 	for dir, chart := range charts {
 		log.Info("\t%s (%s %s) - %s", filepath.Base(dir), chart.Name, chart.Version, chart.Description)
 	}

--- a/action/uninstall.go
+++ b/action/uninstall.go
@@ -10,8 +10,8 @@ import (
 )
 
 func Uninstall(chartName, home, namespace string) {
-	if !chartInstalled(chartName, home) {
-		log.Info("No installed chart named %q. Nothing to delete.", chartName)
+	if !chartFetched(chartName, home) {
+		log.Info("No chart named %q in your workspace. Nothing to delete.", chartName)
 		return
 	}
 
@@ -21,9 +21,11 @@ func Uninstall(chartName, home, namespace string) {
 		log.Die("Failed to load chart: %s", err)
 	}
 
+	log.Info("Running `kubectl delete` ...")
 	if err := deleteChart(c, namespace); err != nil {
 		log.Die("Failed to completely delete chart: %s", err)
 	}
+	log.Info("Done")
 }
 
 func deleteChart(c *chart.Chart, ns string) error {

--- a/action/update.go
+++ b/action/update.go
@@ -23,9 +23,11 @@ func Update(repo, home string) {
 	gitrepo := filepath.Join(home, CacheChartPath)
 	git := ensureRepo(repo, gitrepo)
 
+	log.Info("Updating cache from %s", repo)
 	if err := gitUpdate(git); err != nil {
 		log.Die("Failed to update from Git: %s", err)
 	}
+	log.Info("Done")
 }
 
 // gitUpdate updates a Git repo.
@@ -34,7 +36,7 @@ func gitUpdate(git *vcs.GitRepo) error {
 		return err
 	}
 
-	log.Info("Updated %s from %s", git.LocalPath(), git.Remote())
+	log.Debug("Updated %s from %s", git.LocalPath(), git.Remote())
 	return nil
 }
 
@@ -61,7 +63,7 @@ func ensureRepo(repo, home string) *vcs.GitRepo {
 	git.Logger = log.New()
 
 	if !git.CheckLocal() {
-		log.Info("Cloning repo into %q. Please wait.", home)
+		log.Debug("Cloning repo into %q. Please wait.", home)
 		if err := git.Get(); err != nil {
 			log.Die("Could not create repository in %q: %s", home, err)
 		}
@@ -77,7 +79,7 @@ func ensureHome(home string) {
 
 	for _, p := range must {
 		if fi, err := os.Stat(p); err != nil {
-			log.Info("Creating %s", p)
+			log.Debug("Creating %s", p)
 			if err := os.MkdirAll(p, 0755); err != nil {
 				log.Die("Could not create %q: %s", p, err)
 			}


### PR DESCRIPTION
This PR is an effort to streamline CLI output following a _less is more_ strategy:

 * Move debug statements to `log.Debug`
 * Move `log.Info` statement into public functions so they're easier to find/change
 * Be more consistent with Helm terminology like "cache" and "workspace"
 * Update the README with actual CLI output

There is definitely more we need to do here, but this mostly covers the basic user workflow. Closes #116.