### PR TITLE
fix(create): fix yaml formatting in skeleton manifest

### DIFF
--- a/action/create.go
+++ b/action/create.go
@@ -31,7 +31,7 @@ spec:
   restartPolicy: Never
   containers:
   - name: example
-  image: "alpine:3.2"
+    image: "alpine:3.2"
     command: ["/bin/sleep","9000"]
 `
 


### PR DESCRIPTION
This fixes a bug in YAML formatting that would manifest during:

```
$ helm create mychart
$ helm install mychart
<yaml error>
```