### PR TITLE
fix(action): restore "helm create" tests

### DIFF
--- a/action/create_test.go
+++ b/action/create_test.go
@@ -53,16 +53,16 @@ include that information here.
 	actualManifest := string(manifest)
 	expectedManifest := `---
 apiVersion: v1
-  kind: Pod
-  metadata:
-    name: example-pod
-    heritage: helm
-  spec:
-    restartPolicy: Never
-    containers:
-    - name: example
+kind: Pod
+metadata:
+  name: example-pod
+  heritage: helm
+spec:
+  restartPolicy: Never
+  containers:
+  - name: example
     image: "alpine:3.2"
-      command: ["/bin/sleep","9000"]
+    command: ["/bin/sleep","9000"]
 `
 	expect(t, actualManifest, expectedManifest)
 }


### PR DESCRIPTION
`create_test.go` got left behind in #143 refactoring. This moves it to where it will be run and corrects its expected output. From [Travis CI](https://travis-ci.org/deis/helm/builds/89099840):
```console
$ make test
go test -v ./. ./manifest ./action ./log ./chart ./dependency
...
=== RUN   TestCreate
---> Created chart in /tmp/helm_home044239326/workspace/charts/mychart
--- PASS: TestCreate (0.00s)
=== RUN   TestListChart
...
```