### PR TITLE
fix(.gitignore): hide unit test droppings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-vendor/
-bin/
 _dist/
+bin/
 ci/bintray-ci.json
-
+testdata/helm_home/
+vendor/


### PR DESCRIPTION
Running `make test` creates a testdata/helm_home/ directory which causes git to think the repository has uncommited files. I also alpha-sorted the .gitignore entries, because I could not help myself.