### PR TITLE
add linters to test-style target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
   - make bootstrap build
   - popd
   - export PATH="$PATH:$GLIDE_DIR"
+  - go get github.com/golang/lint/golint
 
 script: make bootstrap build test test-charts
 

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ type Repos struct {
 	// Default is the local name of the default repository.
 	Default string `yaml:"default"`
 	// Tables is a list of table items.
-	Tables []*Table `yaml:tables`
+	Tables []*Table `yaml:"tables"`
 }
 type Workspace struct {
 	// Dir indicates where the workspace is.


### PR DESCRIPTION
Adds a `make test-style` target similar to deis/deis. Runs `gofmt`, `golint`, and `go vet`. See also #113.

TODO:
- [x] Should this also be run by default with `make test`? *Edit:* survey so far says "yes"
- [x] Does this need to vendor in `go vet` and `golint` with `glide` or `go get` or...um... *Edit:* no, just `golint` in Travis CI
- [x] `make test` fails for me already in master, see below *Edit:* fixed by wiping out and starting over with $GOPATH + `glide`
- [x] Fix travis CI error about `read` binary