### PR TITLE
fix(release): skip update version checks on Travis

### DIFF
--- a/action/update_test.go
+++ b/action/update_test.go
@@ -33,6 +33,9 @@ func TestEnsureRepo(t *testing.T) {
 }
 
 func TestCheckLatest(t *testing.T) {
+	if exists := os.Getenv("CI"); exists != "" {
+		t.Skip("skipping test to prevent getting rate limited by github")
+	}
 	var oldRepo = release.Project
 	var oldOwner = release.Owner
 	var b bytes.Buffer

--- a/release/latest_test.go
+++ b/release/latest_test.go
@@ -1,10 +1,14 @@
 package release
 
 import (
+	"os"
 	"testing"
 )
 
 func TestLatest(t *testing.T) {
+	if exists := os.Getenv("CI"); exists != "" {
+		t.Skip("skipping test to prevent getting rate limited by github")
+	}
 	rr, err := Latest()
 	if err != nil {
 		t.Errorf("Failed to get latest: %s", err)
@@ -16,6 +20,9 @@ func TestLatest(t *testing.T) {
 }
 
 func TestLatestVersion(t *testing.T) {
+	if exists := os.Getenv("CI"); exists != "" {
+		t.Skip("skipping test to prevent getting rate limited by github")
+	}
 	v, err := LatestVersion()
 	if err != nil {
 		t.Error(err)
@@ -27,6 +34,9 @@ func TestLatestVersion(t *testing.T) {
 }
 
 func TestLatestDownloadURL(t *testing.T) {
+	if exists := os.Getenv("CI"); exists != "" {
+		t.Skip("skipping test to prevent getting rate limited by github")
+	}
 	v, err := LatestDownloadURL()
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
this is done to prevent rate limiting by github until we find a better
solution.

Sorry @technosophos!