### PR TITLE
feat(*): add 'home' subcommand

### DIFF
--- a/helm.go
+++ b/helm.go
@@ -262,6 +262,14 @@ list all available charts.
 			},
 		},
 		{
+			Name:      "home",
+			Usage:     "Displays the location of the Helm home.",
+			ArgsUsage: "",
+			Action: func(c *cli.Context) {
+				log.Msg(home(c))
+			},
+		},
+		{
 			Name:    "repo",
 			Aliases: []string{"repository"},
 			Usage:   "Work with other Chart repositories.",


### PR DESCRIPTION
This is for shell scripts that need to determine the location of
Helm's home directory.

Example: 

```
cd $(helm home)
```