### PR TITLE
[WIP] feat(Makefile): use pretty version identifiers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,6 @@
-VERSION := $(shell git describe --tags --abbrev=0 2>/dev/null)+$(shell git rev-parse --short HEAD)
+VERSION := $(shell git describe --tags 2>/dev/null)
 DIST_DIRS := find * -type d -exec
 export GO15VENDOREXPERIMENT=1
-
-ifndef VERSION
-  VERSION := git-$(shell git rev-parse --short HEAD)
-endif
 
 bootstrap:
 	glide -y glide-full.yaml up


### PR DESCRIPTION
Simplifies the `VERSION` var in the Makefile to only include the `git` SHA if the commit isn't the same as a tag. Easy thanks to [`git describe`](https://git-scm.com/docs/git-describe). 

This assumes there is at least one tag already in the repository, and the format differs slightly from what was requested, since it includes the # of commits since the tag before the short SHA.

Closes #141.

```console
$ make build
go build -o bin/helm -ldflags "-X main.version=0.1.0-7-g7f8549d" helm.go
$ bin/helm --version
helm version 0.1.0-7-g7f8549d
$ git checkout 0.1.0
$ # (backport this change into the Makefile)
$ make build
go build -o bin/helm -ldflags "-X main.version=0.1.0" helm.go
$ bin/helm --version
helm version 0.1.0
```