### PR TITLE
[WIP] feat(plugin): add plugin support

### DIFF
--- a/action/plugin.go
+++ b/action/plugin.go
@@ -1,0 +1,52 @@
+package action
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/deis/helm/log"
+)
+
+// Plugin attepmts to execute a plugin.
+//
+// It looks on the path for an executable named `helm-COMMAND`, and executes
+// that, passing it all of the arguments received after the subcommand.
+//
+// Output is passed directly back to the user.
+//
+// This ensures that the following environment variables are set:
+//
+//	- $HELM_HOME: points to the user's Helm home directory.
+// 	- $HELM_DEFAULT_REPO: the local name of the default repository.
+func Plugin(homedir, cmd string, args []string) {
+	if abs, err := filepath.Abs(homedir); err == nil {
+		homedir = abs
+	}
+	os.Setenv("HELM_HOME", homedir)
+	os.Setenv("HELM_DEFAULT_REPO", mustConfig(homedir).Repos.Default)
+
+	cmd = PluginName(cmd)
+	execPlugin(cmd, args)
+}
+
+func HasPlugin(name string) bool {
+	name = PluginName(name)
+	_, err := exec.LookPath(name)
+	return err == nil
+}
+
+func PluginName(name string) string {
+	return "helm-" + name
+}
+
+func execPlugin(name string, args []string) {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Run(); err != nil {
+		log.Die(err.Error())
+	}
+}

--- a/action/plugin_test.go
+++ b/action/plugin_test.go
@@ -1,0 +1,44 @@
+package action
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPluginName(t *testing.T) {
+	if PluginName("foo") != "helm-foo" {
+		t.Errorf("Expected helm-foo, got %s", PluginName("foo"))
+	}
+}
+
+func TestPlugin(t *testing.T) {
+	f := "../testdata"
+	p := "plugin"
+	a := []string{"-a", "-b", "-c"}
+
+	os.Setenv("PATH", os.ExpandEnv("$PATH:"+helmRoot+"/testdata"))
+
+	buf, err := ioutil.TempFile("", "helm-plugin-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	oldout := os.Stdout
+	os.Stdout = buf
+	defer func() { os.Stdout = oldout; buf.Close(); os.Remove(buf.Name()) }()
+
+	fakeUpdate(f)
+	Plugin(f, p, a)
+
+	buf.Seek(0, 0)
+	b, err := ioutil.ReadAll(buf)
+	if err != nil {
+		t.Errorf("Failed to read tmp file: %s", err)
+	}
+
+	if strings.TrimSpace(string(b)) != "HELLO -a -b -c" {
+		t.Errorf("Expected 'HELLO -a -b -c', got %v", string(b))
+	}
+}

--- a/helm.go
+++ b/helm.go
@@ -51,6 +51,10 @@ ENVIRONMENT:
 	}
 
 	app.CommandNotFound = func(c *cli.Context, command string) {
+		if action.HasPlugin(command) {
+			action.Plugin(home(c), command, c.Args())
+			return
+		}
 		log.Err("No matching command '%s'", command)
 		cli.ShowAppHelp(c)
 		log.Die("")

--- a/testdata/helm-plugin
+++ b/testdata/helm-plugin
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo HELLO $@


### PR DESCRIPTION
Following the CLI style of Git, this provides a simple extension mechanism that allows you to put stand-alone tools on `$PATH` and then have them execute "as if" they were part of Helm.

Example:

```
$ helm foo
```

Behind the scenes, this searches for `$PATH/helm-foo`. It passes that command a number of environment variables for ease of use.

Use case: Make it easy for teams to integrate custom tooling into Helm.