### PR TITLE
chore(.travis.yml): update glide to 0.7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ go:
   - 1.5.1
 
 install:
-  - wget "https://github.com/Masterminds/glide/releases/download/0.7.1/glide-0.7.1-linux-amd64.tar.gz"
+  - wget "https://github.com/Masterminds/glide/releases/download/0.7.2/glide-0.7.2-linux-amd64.tar.gz"
   - mkdir -p $HOME/bin
-  - tar -vxz -C $HOME/bin --strip=1 -f glide-0.7.1-linux-amd64.tar.gz
+  - tar -vxz -C $HOME/bin --strip=1 -f glide-0.7.2-linux-amd64.tar.gz
   - export PATH="$HOME/bin:$PATH" GLIDE_HOME="$HOME/.glide"
   - go get github.com/golang/lint/golint
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For more detailed information on the project roadmap, see the [GitHub milestones
 
 - Make sure you have a `kubectl` client installed and configured to speak with a running Kubernetes cluster.
 - Helm requires Go 1.5
-- Install [glide](https://github.com/Masterminds/glide) >= 0.7.0
+- Install [glide](https://github.com/Masterminds/glide) >= 0.7.2
 - Run the following commands:
 
 ```console


### PR DESCRIPTION
See https://github.com/Masterminds/glide/releases/tag/0.7.2

I had talked with @technosophos about the annoying re-ordering bug, so this seems like a fix we want.

~~(Note that Homebrew still has only glide 0.7.1 as of this morning.)~~ Updated in `brew` now as well.